### PR TITLE
Add activity logging API and front-end interface

### DIFF
--- a/novasystem-io/src/routes/+page.svelte
+++ b/novasystem-io/src/routes/+page.svelte
@@ -1,2 +1,604 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to read the documentation</p>
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  const API_BASE = 'http://localhost:8000';
+
+  type LogDocument = {
+    id: number;
+    log_id: number;
+    doc_type: string;
+    title: string;
+    notes: string | null;
+    created_at: string;
+    download_url: string;
+  };
+
+  type LogEntry = {
+    id: number;
+    created_at: string;
+    activity: string;
+    details: string | null;
+    tags: string[];
+    metadata: Record<string, unknown>;
+    documents: LogDocument[];
+  };
+
+  let activity = '';
+  let details = '';
+  let tags = '';
+  let metadataInput = '';
+  let logs: LogEntry[] = [];
+  let loading = false;
+  let isFetching = false;
+  let errorMessage = '';
+  let successMessage = '';
+
+  let filterSearch = '';
+  let filterTag = '';
+  let filterStart = '';
+  let filterEnd = '';
+  let filterLimit = 50;
+
+  let documentNotes: Record<number, string> = {};
+  let documentStatus: Record<number, string> = {};
+
+  onMount(() => {
+    fetchLogs();
+  });
+
+  const buildQueryString = () => {
+    const params = new URLSearchParams();
+    if (filterSearch.trim()) params.set('search', filterSearch.trim());
+    if (filterTag.trim()) params.set('tag', filterTag.trim());
+    if (filterStart) params.set('start', new Date(filterStart).toISOString());
+    if (filterEnd) params.set('end', new Date(filterEnd).toISOString());
+    if (filterLimit) params.set('limit', String(filterLimit));
+    return params.toString();
+  };
+
+  const fetchLogs = async () => {
+    isFetching = true;
+    errorMessage = '';
+    try {
+      const query = buildQueryString();
+      const response = await fetch(`${API_BASE}/api/logs${query ? `?${query}` : ''}`);
+      if (!response.ok) {
+        throw new Error('Failed to load log entries.');
+      }
+      const payload = await response.json();
+      logs = payload.items ?? [];
+    } catch (error) {
+      errorMessage = error instanceof Error ? error.message : 'Unexpected error while fetching logs.';
+    } finally {
+      isFetching = false;
+    }
+  };
+
+  const parseTags = (value: string) =>
+    value
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+
+  const parseMetadata = () => {
+    const trimmed = metadataInput.trim();
+    if (!trimmed) return {};
+    try {
+      return JSON.parse(trimmed);
+    } catch (error) {
+      throw new Error('Metadata must be valid JSON.');
+    }
+  };
+
+  const resetForm = () => {
+    activity = '';
+    details = '';
+    tags = '';
+    metadataInput = '';
+  };
+
+  const submitLog = async () => {
+    errorMessage = '';
+    successMessage = '';
+    loading = true;
+    try {
+      const metadata = parseMetadata();
+      const response = await fetch(`${API_BASE}/api/logs`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          activity: activity.trim(),
+          details: details.trim() || null,
+          tags: parseTags(tags),
+          metadata
+        })
+      });
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || 'Unable to record log entry.');
+      }
+      const newLog: LogEntry = await response.json();
+      successMessage = 'Activity recorded successfully.';
+      logs = [newLog, ...logs];
+      resetForm();
+    } catch (error) {
+      errorMessage = error instanceof Error ? error.message : 'Unexpected error while saving the log entry.';
+    } finally {
+      loading = false;
+    }
+  };
+
+  const handleSubmit = async (event: SubmitEvent) => {
+    event.preventDefault();
+    if (!activity.trim()) {
+      errorMessage = 'Activity description is required.';
+      return;
+    }
+    await submitLog();
+  };
+
+  const updateDocumentNotes = (logId: number, value: string) => {
+    documentNotes = { ...documentNotes, [logId]: value };
+  };
+
+  const generateDocument = async (log: LogEntry, docType: string) => {
+    errorMessage = '';
+    successMessage = '';
+    documentStatus = { ...documentStatus, [log.id]: 'Generating document…' };
+    try {
+      const response = await fetch(`${API_BASE}/api/logs/${log.id}/documents`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          doc_type: docType,
+          notes: documentNotes[log.id]?.trim() || null
+        })
+      });
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || 'Failed to generate document.');
+      }
+      const document: LogDocument = await response.json();
+      const updatedLogs = logs.map((entry) =>
+        entry.id === log.id ? { ...entry, documents: [...entry.documents, document] } : entry
+      );
+      logs = updatedLogs;
+      documentNotes = { ...documentNotes, [log.id]: '' };
+      documentStatus = { ...documentStatus, [log.id]: 'Document ready.' };
+      successMessage = `Document generated: ${document.title}`;
+    } catch (error) {
+      documentStatus = { ...documentStatus, [log.id]: '' };
+      errorMessage = error instanceof Error ? error.message : 'Unexpected error while generating document.';
+    }
+  };
+
+  const formatDate = (value: string) => new Date(value).toLocaleString();
+</script>
+
+<svelte:head>
+  <title>NovaSystem Activity Log</title>
+</svelte:head>
+
+<main class="layout">
+  <section class="panel">
+    <h1>Activity Log</h1>
+    <p class="lead">Capture your ongoing work, generate supporting documents, and search the history.</p>
+
+    {#if errorMessage}
+      <div class="alert alert-error">{errorMessage}</div>
+    {/if}
+    {#if successMessage}
+      <div class="alert alert-success">{successMessage}</div>
+    {/if}
+
+    <form class="log-form" on:submit|preventDefault={handleSubmit}>
+      <div class="field">
+        <label for="activity">Activity*</label>
+        <input id="activity" bind:value={activity} placeholder="Summarise what happened" required />
+      </div>
+      <div class="field">
+        <label for="details">Details</label>
+        <textarea
+          id="details"
+          bind:value={details}
+          rows={4}
+          placeholder="Add context, blockers, or outcomes"
+        ></textarea>
+      </div>
+      <div class="field-group">
+        <div class="field">
+          <label for="tags">Tags</label>
+          <input id="tags" bind:value={tags} placeholder="Comma separated (e.g. research, client)" />
+        </div>
+        <div class="field">
+          <label for="metadata">Metadata (JSON)</label>
+          <input id="metadata" bind:value={metadataInput} placeholder='{"project": "Nova"}' />
+        </div>
+      </div>
+      <button type="submit" class="primary" disabled={loading}>
+        {#if loading}
+          Saving…
+        {:else}
+          Save activity
+        {/if}
+      </button>
+    </form>
+  </section>
+
+  <section class="panel">
+    <header class="list-header">
+      <h2>History</h2>
+      <button class="secondary" on:click={fetchLogs} disabled={isFetching}>
+        {#if isFetching}
+          Refreshing…
+        {:else}
+          Refresh
+        {/if}
+      </button>
+    </header>
+
+    <div class="filters">
+      <div class="field">
+        <label for="search">Search</label>
+        <input id="search" bind:value={filterSearch} placeholder="Keyword" />
+      </div>
+      <div class="field">
+        <label for="filter-tag">Tag</label>
+        <input id="filter-tag" bind:value={filterTag} placeholder="Tag value" />
+      </div>
+      <div class="field">
+        <label for="start">Start</label>
+        <input id="start" type="datetime-local" bind:value={filterStart} />
+      </div>
+      <div class="field">
+        <label for="end">End</label>
+        <input id="end" type="datetime-local" bind:value={filterEnd} />
+      </div>
+      <div class="field">
+        <label for="limit">Limit</label>
+        <input id="limit" type="number" min="1" max="500" bind:value={filterLimit} />
+      </div>
+      <button class="secondary" on:click={fetchLogs} disabled={isFetching}>Apply filters</button>
+    </div>
+
+    {#if logs.length === 0}
+      <p class="empty">No activity logged yet. Add your first entry above.</p>
+    {:else}
+      <ul class="log-list">
+        {#each logs as log (log.id)}
+          <li class="log-card">
+            <div class="log-summary">
+              <h3>{log.activity}</h3>
+              <p class="timestamp">{formatDate(log.created_at)}</p>
+              {#if log.details}
+                <p class="details">{log.details}</p>
+              {/if}
+              {#if log.tags?.length}
+                <div class="tags">
+                  {#each log.tags as tag}
+                    <span class="tag">{tag}</span>
+                  {/each}
+                </div>
+              {/if}
+              {#if Object.keys(log.metadata ?? {}).length}
+                <div class="metadata">
+                  <h4>Metadata</h4>
+                  <dl>
+                    {#each Object.entries(log.metadata) as [key, value]}
+                      <div>
+                        <dt>{key}</dt>
+                        <dd>{String(value)}</dd>
+                      </div>
+                    {/each}
+                  </dl>
+                </div>
+              {/if}
+            </div>
+            <div class="log-actions">
+              <label for={`notes-${log.id}`}>Document notes</label>
+              <textarea
+                id={`notes-${log.id}`}
+                rows={3}
+                value={documentNotes[log.id] ?? ''}
+                on:input={(event) => updateDocumentNotes(log.id, (event.target as HTMLTextAreaElement).value)}
+                placeholder="Add instructions for the generated document"
+              ></textarea>
+              <button class="secondary" on:click={() => generateDocument(log, 'work_summary')}>
+                Generate work summary
+              </button>
+              {#if documentStatus[log.id]}
+                <p class="status">{documentStatus[log.id]}</p>
+              {/if}
+              {#if log.documents.length}
+                <div class="documents">
+                  <h4>Documents</h4>
+                  <ul>
+                    {#each log.documents as document}
+                      <li>
+                        <a href={`${API_BASE}${document.download_url}`} target="_blank" rel="noopener noreferrer">
+                          {document.title}
+                        </a>
+                        <span class="timestamp">{formatDate(document.created_at)}</span>
+                      </li>
+                    {/each}
+                  </ul>
+                </div>
+              {/if}
+            </div>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </section>
+</main>
+
+<style>
+  :global(body) {
+    margin: 0;
+    font-family: 'Inter', system-ui, sans-serif;
+    background: #f3f4f6;
+    color: #1f2937;
+  }
+
+  .layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1.5rem;
+    padding: 2rem;
+    max-width: 1100px;
+    margin: 0 auto;
+  }
+
+  .panel {
+    background: white;
+    border-radius: 1rem;
+    padding: 1.75rem;
+    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.1);
+  }
+
+  h1 {
+    margin: 0 0 0.5rem;
+    font-size: 2rem;
+  }
+
+  h2 {
+    margin: 0;
+  }
+
+  h3 {
+    margin: 0;
+    font-size: 1.125rem;
+  }
+
+  .lead {
+    margin-top: 0;
+    color: #4b5563;
+  }
+
+  .alert {
+    padding: 0.75rem 1rem;
+    border-radius: 0.75rem;
+    margin-bottom: 1rem;
+    font-weight: 500;
+  }
+
+  .alert-error {
+    background: #fee2e2;
+    color: #b91c1c;
+  }
+
+  .alert-success {
+    background: #dcfce7;
+    color: #15803d;
+  }
+
+  .log-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .field-group {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1rem;
+  }
+
+  label {
+    font-weight: 600;
+    color: #374151;
+  }
+
+  input,
+  textarea,
+  button {
+    font-family: inherit;
+  }
+
+  input,
+  textarea {
+    padding: 0.75rem;
+    border-radius: 0.75rem;
+    border: 1px solid #d1d5db;
+    background: #f9fafb;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  input:focus,
+  textarea:focus {
+    outline: none;
+    border-color: #6366f1;
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+    background: white;
+  }
+
+  button {
+    border: none;
+    border-radius: 9999px;
+    padding: 0.75rem 1.5rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+  }
+
+  button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+  }
+
+  .primary {
+    background: linear-gradient(120deg, #4f46e5, #7c3aed);
+    color: white;
+    box-shadow: 0 10px 20px rgba(99, 102, 241, 0.25);
+  }
+
+  .secondary {
+    background: #e0e7ff;
+    color: #312e81;
+  }
+
+  .primary:hover:not(:disabled),
+  .secondary:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 24px rgba(79, 70, 229, 0.15);
+  }
+
+  .list-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+  }
+
+  .filters {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .empty {
+    margin: 2rem 0;
+    text-align: center;
+    color: #6b7280;
+  }
+
+  .log-list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin: 0;
+    padding: 0;
+  }
+
+  .log-card {
+    border: 1px solid #e5e7eb;
+    border-radius: 1rem;
+    padding: 1.25rem;
+    display: grid;
+    gap: 1.25rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  }
+
+  .log-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .timestamp {
+    color: #6b7280;
+    font-size: 0.9rem;
+  }
+
+  .details {
+    margin: 0;
+  }
+
+  .tags {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .tag {
+    background: #eef2ff;
+    color: #4338ca;
+    padding: 0.25rem 0.6rem;
+    border-radius: 9999px;
+    font-size: 0.8rem;
+  }
+
+  .metadata h4 {
+    margin: 0;
+    font-size: 0.95rem;
+  }
+
+  .metadata dl {
+    margin: 0.25rem 0 0;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.2rem 1rem;
+    font-size: 0.9rem;
+  }
+
+  .metadata dt {
+    font-weight: 600;
+    color: #374151;
+  }
+
+  .metadata dd {
+    margin: 0;
+    color: #4b5563;
+  }
+
+  .log-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .log-actions textarea {
+    resize: vertical;
+  }
+
+  .status {
+    margin: 0;
+    font-size: 0.85rem;
+    color: #2563eb;
+  }
+
+  .documents ul {
+    list-style: none;
+    margin: 0.5rem 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .documents a {
+    color: #4f46e5;
+    text-decoration: none;
+    font-weight: 600;
+  }
+
+  .documents a:hover {
+    text-decoration: underline;
+  }
+
+  @media (min-width: 900px) {
+    .layout {
+      grid-template-columns: minmax(0, 420px) minmax(0, 1fr);
+    }
+  }
+</style>

--- a/waitaminute/novasystemcore/README.md
+++ b/waitaminute/novasystemcore/README.md
@@ -1,3 +1,29 @@
+# NovaSystem Logging & Document Service
+
+This package now includes a FastAPI-based service that powers the activity logging UI. The service exposes endpoints for
+recording work, generating auxiliary documents, and querying historical entries with SQL-backed persistence.
+
+## Quick start
+
+```bash
+# Install dependencies
+pip install -r ../requirements.txt
+
+# Start the API (serves on http://localhost:8000 by default)
+uvicorn waitaminute.novasystemcore.app:app --reload
+```
+
+Key API routes:
+
+- `POST /api/logs` &mdash; add a new activity entry. The payload is stored in SQLite, appended to `data/activity.log.jsonl`, and
+  returned to the caller.
+- `GET /api/logs` &mdash; search the activity history using optional keyword, tag, and date filters.
+- `POST /api/logs/{id}/documents` &mdash; generate Markdown summaries tied to a log entry. Files are written under
+  `data/documents/` and are available via `/documents/<filename>` for direct download.
+- `GET /api/documents` &mdash; list every generated artifact.
+
+The service automatically creates the SQLite database and storage folders under `waitaminute/novasystemcore/data/`.
+
 # Welcome to the NovaSystem SDK
 
 Absolutely! Let's go through each component step by step and construct examples within the context of the NovaSystem code we've developed together. I'll take my time to ensure clarity and accuracy.

--- a/waitaminute/novasystemcore/app.py
+++ b/waitaminute/novasystemcore/app.py
@@ -1,0 +1,188 @@
+"""FastAPI application providing the NovaSystem logging API."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from fastapi import Depends, FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+from sqlalchemy import or_, select
+from sqlalchemy.orm import Session
+
+from .database import SessionLocal, init_db
+from .logging_service import DOCUMENT_DIR, append_to_log_file, create_document_file
+from .models import ActivityLog, DocumentArtifact
+from .schemas import DocumentCreate, DocumentResponse, LogCreate, LogListResponse, LogResponse
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="NovaSystem Logging Service", version="1.0.0")
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    @app.on_event("startup")
+    def _startup() -> None:  # pragma: no cover - executed by runtime
+        init_db()
+        DOCUMENT_DIR.mkdir(parents=True, exist_ok=True)
+
+    app.mount("/documents", StaticFiles(directory=DOCUMENT_DIR), name="documents")
+
+    def get_session() -> Session:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    def serialise_document(document: DocumentArtifact) -> DocumentResponse:
+        file_path = Path(document.path) if document.path else None
+        download_url = f"/documents/{file_path.name}" if file_path else ""
+        return DocumentResponse(
+            id=document.id,
+            log_id=document.log_id,
+            doc_type=document.doc_type,
+            title=document.title,
+            notes=document.notes,
+            created_at=document.created_at,
+            download_url=download_url,
+        )
+
+    def serialise_log(log: ActivityLog) -> LogResponse:
+        documents = [serialise_document(document) for document in log.documents]
+        return LogResponse(
+            id=log.id,
+            created_at=log.created_at,
+            activity=log.activity,
+            details=log.details,
+            tags=log.tags or [],
+            metadata=log.metadata or {},
+            documents=documents,
+        )
+
+    @app.post("/api/logs", response_model=LogResponse, status_code=201)
+    def create_log(payload: LogCreate, session: Session = Depends(get_session)) -> LogResponse:
+        record = ActivityLog(
+            activity=payload.activity,
+            details=payload.details,
+            tags=payload.tags,
+            metadata=payload.metadata,
+        )
+        session.add(record)
+        session.commit()
+        session.refresh(record)
+
+        append_to_log_file(
+            {
+                "id": record.id,
+                "activity": record.activity,
+                "details": record.details,
+                "tags": record.tags,
+                "metadata": record.metadata,
+                "created_at": record.created_at.isoformat(),
+            }
+        )
+
+        return serialise_log(record)
+
+    @app.get("/api/logs", response_model=LogListResponse)
+    def list_logs(
+        session: Session = Depends(get_session),
+        search: str | None = Query(None, description="Search across activity and details."),
+        tag: str | None = Query(None, description="Filter logs by a tag value."),
+        start: datetime | None = Query(None, description="Earliest creation timestamp."),
+        end: datetime | None = Query(None, description="Latest creation timestamp."),
+        limit: int = Query(100, ge=1, le=500, description="Maximum number of records to return."),
+    ) -> LogListResponse:
+        query = select(ActivityLog)
+
+        if search:
+            like_term = f"%{search.lower()}%"
+            query = query.where(
+                or_(
+                    ActivityLog.activity.ilike(like_term),
+                    ActivityLog.details.ilike(like_term),
+                )
+            )
+        if tag:
+            query = query.where(ActivityLog.tags.contains([tag]))
+        if start:
+            query = query.where(ActivityLog.created_at >= start)
+        if end:
+            query = query.where(ActivityLog.created_at <= end)
+
+        query = query.order_by(ActivityLog.created_at.desc()).limit(limit)
+
+        logs = session.scalars(query).all()
+        for log in logs:
+            _ = log.documents
+        return LogListResponse(items=[serialise_log(log) for log in logs])
+
+    @app.get("/api/logs/{log_id}", response_model=LogResponse)
+    def get_log(log_id: int, session: Session = Depends(get_session)) -> LogResponse:
+        log = session.get(ActivityLog, log_id)
+        if not log:
+            raise HTTPException(status_code=404, detail="Log entry not found")
+        _ = log.documents
+        return serialise_log(log)
+
+    @app.post("/api/logs/{log_id}/documents", response_model=DocumentResponse, status_code=201)
+    def create_document(log_id: int, payload: DocumentCreate, session: Session = Depends(get_session)) -> DocumentResponse:
+        log = session.get(ActivityLog, log_id)
+        if not log:
+            raise HTTPException(status_code=404, detail="Log entry not found")
+
+        log_data = {
+            "id": log.id,
+            "created_at": log.created_at.isoformat(),
+            "activity": log.activity,
+            "details": log.details,
+            "tags": log.tags or [],
+            "metadata": log.metadata or {},
+        }
+        document_path = create_document_file(payload.doc_type, log_data, payload.notes)
+        document = DocumentArtifact(
+            log_id=log.id,
+            doc_type=payload.doc_type,
+            title=f"{payload.doc_type.replace('_', ' ').title()} for log {log.id}",
+            notes=payload.notes,
+            path=str(document_path),
+        )
+        session.add(document)
+        session.commit()
+        session.refresh(document)
+
+        return DocumentResponse(
+            id=document.id,
+            log_id=log.id,
+            doc_type=document.doc_type,
+            title=document.title,
+            notes=document.notes,
+            created_at=document.created_at,
+            download_url=f"/documents/{document_path.name}",
+        )
+
+    @app.get("/api/documents", response_model=list[DocumentResponse])
+    def list_documents(session: Session = Depends(get_session)) -> list[DocumentResponse]:
+        documents = session.scalars(select(DocumentArtifact).order_by(DocumentArtifact.created_at.desc())).all()
+        return [serialise_document(document) for document in documents]
+
+    @app.get("/api/documents/{document_id}")
+    def download_document(document_id: int, session: Session = Depends(get_session)) -> FileResponse:
+        document = session.get(DocumentArtifact, document_id)
+        if not document:
+            raise HTTPException(status_code=404, detail="Document not found")
+        file_path = Path(document.path)
+        if not file_path.exists():
+            raise HTTPException(status_code=404, detail="Document file missing")
+        return FileResponse(file_path, media_type="text/markdown", filename=file_path.name)
+
+    return app
+
+
+app = create_app()

--- a/waitaminute/novasystemcore/database.py
+++ b/waitaminute/novasystemcore/database.py
@@ -1,0 +1,30 @@
+"""Database configuration for the NovaSystem logging service."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import DeclarativeBase, sessionmaker
+
+
+class Base(DeclarativeBase):
+    """Base class for declarative SQLAlchemy models."""
+
+
+DATA_DIR = Path(os.environ.get("NOVASYSTEM_DATA_DIR", Path(__file__).resolve().parent / "data"))
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+DB_PATH = Path(os.environ.get("NOVASYSTEM_DB_PATH", DATA_DIR / "activity.db"))
+ENGINE = create_engine(f"sqlite:///{DB_PATH}", connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(bind=ENGINE, autoflush=False, autocommit=False)
+
+
+def init_db() -> None:
+    """Initialise the SQLite database and create all tables."""
+    from . import models  # noqa: F401  # imported for side effects
+
+    Base.metadata.create_all(bind=ENGINE)
+
+
+__all__ = ["Base", "ENGINE", "SessionLocal", "init_db", "DATA_DIR", "DB_PATH"]

--- a/waitaminute/novasystemcore/logging_service.py
+++ b/waitaminute/novasystemcore/logging_service.py
@@ -1,0 +1,60 @@
+"""Core logging and document creation helpers."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .database import DATA_DIR
+
+LOG_FILE = DATA_DIR / "activity.log.jsonl"
+DOCUMENT_DIR = DATA_DIR / "documents"
+DOCUMENT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def append_to_log_file(entry: dict[str, Any]) -> None:
+    """Append the provided entry to the JSONL log file."""
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    serialisable = {
+        "timestamp": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        **entry,
+    }
+    with LOG_FILE.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(serialisable, ensure_ascii=False) + "\n")
+
+
+def build_document_content(doc_type: str, log_entry: dict[str, Any], notes: str | None) -> str:
+    """Create human-readable content for generated documents."""
+    created_at = log_entry.get("created_at")
+    created_str = created_at if isinstance(created_at, str) else str(created_at)
+    header = f"# {doc_type.replace('_', ' ').title()}\n\n"
+    summary = f"- **Log ID:** {log_entry['id']}\n- **Created:** {created_str}\n- **Activity:** {log_entry['activity']}\n"
+    details = log_entry.get("details")
+    if details:
+        summary += f"- **Details:** {details}\n"
+    tags = log_entry.get("tags") or []
+    if tags:
+        summary += f"- **Tags:** {', '.join(tags)}\n"
+    metadata = log_entry.get("metadata") or {}
+    if metadata:
+        metadata_lines = "\n".join(f"    - {key}: {value}" for key, value in metadata.items())
+        summary += f"- **Metadata:**\n{metadata_lines}\n"
+
+    sections = [header, summary, "\n## Notes\n", (notes or "No additional notes supplied.") + "\n"]
+    sections.append("\n## Next Steps\n- [ ] Define follow-up tasks\n- [ ] Capture dependencies\n- [ ] Update the main activity log if plans change\n")
+    return "".join(sections)
+
+
+def create_document_file(doc_type: str, log_entry: dict[str, Any], notes: str | None) -> Path:
+    """Generate a markdown document for the log entry and return the file path."""
+    DOCUMENT_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%S")
+    file_name = f"log-{log_entry['id']}-{doc_type}-{timestamp}.md"
+    file_path = DOCUMENT_DIR / file_name
+    content = build_document_content(doc_type, log_entry, notes)
+    file_path.write_text(content, encoding="utf-8")
+    return file_path
+
+
+__all__ = ["append_to_log_file", "create_document_file", "LOG_FILE", "DOCUMENT_DIR"]

--- a/waitaminute/novasystemcore/models.py
+++ b/waitaminute/novasystemcore/models.py
@@ -1,0 +1,46 @@
+"""SQLAlchemy models for activity logging."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .database import Base
+
+
+class ActivityLog(Base):
+    """Represents a single activity that has been logged."""
+
+    __tablename__ = "activity_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+    activity: Mapped[str] = mapped_column(String(255), nullable=False)
+    details: Mapped[str | None] = mapped_column(Text)
+    tags: Mapped[list[str]] = mapped_column(JSON, default=list)
+    metadata: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
+
+    documents: Mapped[list["DocumentArtifact"]] = relationship(
+        "DocumentArtifact", back_populates="log", cascade="all, delete-orphan"
+    )
+
+
+class DocumentArtifact(Base):
+    """Represents an auxiliary document generated for a log entry."""
+
+    __tablename__ = "documents"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    log_id: Mapped[int] = mapped_column(ForeignKey("activity_logs.id", ondelete="CASCADE"), nullable=False, index=True)
+    doc_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    path: Mapped[str] = mapped_column(String(500), nullable=False)
+    notes: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+
+    log: Mapped[ActivityLog] = relationship("ActivityLog", back_populates="documents")
+
+
+__all__ = ["ActivityLog", "DocumentArtifact"]

--- a/waitaminute/novasystemcore/schemas.py
+++ b/waitaminute/novasystemcore/schemas.py
@@ -1,0 +1,58 @@
+"""Pydantic schemas for the logging service API."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class DocumentCreate(BaseModel):
+    doc_type: str = Field(..., description="Type of document to generate, e.g. 'work_summary'.")
+    notes: str | None = Field(None, description="Optional notes to embed in the generated document.")
+
+
+class DocumentResponse(BaseModel):
+    id: int
+    log_id: int
+    doc_type: str
+    title: str
+    notes: str | None
+    created_at: datetime
+    download_url: str
+
+
+class LogCreate(BaseModel):
+    activity: str = Field(..., min_length=1, description="Short description of the activity performed.")
+    details: str | None = Field(None, description="Extended narrative or supporting information.")
+    tags: list[str] = Field(default_factory=list, description="Optional tags to classify the activity.")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Additional structured metadata.")
+
+    @field_validator("tags", mode="before")
+    def _normalise_tags(cls, value: Any) -> list[str]:
+        if isinstance(value, str):
+            return [t.strip() for t in value.split(",") if t.strip()]
+        return list(value or [])
+
+
+class LogResponse(BaseModel):
+    id: int
+    created_at: datetime
+    activity: str
+    details: str | None
+    tags: list[str]
+    metadata: dict[str, Any]
+    documents: list[DocumentResponse] = Field(default_factory=list)
+
+
+class LogListResponse(BaseModel):
+    items: list[LogResponse]
+
+
+__all__ = [
+    "DocumentCreate",
+    "DocumentResponse",
+    "LogCreate",
+    "LogResponse",
+    "LogListResponse",
+]

--- a/waitaminute/requirements.txt
+++ b/waitaminute/requirements.txt
@@ -1,0 +1,5 @@
+fastapi>=0.110.0
+uvicorn[standard]>=0.27.0
+sqlalchemy>=2.0.25
+pydantic>=2.6.0
+python-multipart>=0.0.7


### PR DESCRIPTION
## Summary
- replace the placeholder Svelte landing page with an activity logging dashboard that can submit entries, filter history, and request auxiliary documents
- implement a FastAPI service with SQLite-backed models, JSONL file logging, and markdown document generation plus download endpoints
- add backend dependencies and README guidance for running the new logging service

## Testing
- `npm run build` *(fails: vite binary unavailable in sandbox)*
- `pip install -r waitaminute/requirements.txt` *(fails: proxy blocks PyPI downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68cc37a05fd883208a92ce4bff100bbb