### PR TITLE
feat: add logging backend service and production API

### DIFF
--- a/waitaminute/novasystemcore/display/main.py
+++ b/waitaminute/novasystemcore/display/main.py
@@ -1,64 +1,30 @@
-import sys
-sys.path.append("..")
+"""Utility entry point for running the NovaSystem API locally."""
+from __future__ import annotations
 
-import gradio as gr
-from abc import ABC, abstractmethod
-from bots.Bot import Bot
+import os
+
+import uvicorn
+
+from ..app import create_app
 
 
-class TestBot(Bot):
-    def __init__(self, config):
-        super().__init__(config)
+def main() -> None:
+    """Launch the FastAPI application using uvicorn."""
 
-    def execute(self, input_text):
-        self.log(f"Received input: {input_text}")
-        # Add your custom bot logic here
-        output_text = f"TestBot processed input: {input_text}"
-        return output_text
+    app = create_app()
+    host = os.environ.get("NOVASYSTEM_HOST", "0.0.0.0")
+    port = int(os.environ.get("NOVASYSTEM_PORT", "8000"))
+    reload_enabled = os.environ.get("NOVASYSTEM_RELOAD", "false").lower() == "true"
+    log_level = os.environ.get("NOVASYSTEM_LOG_LEVEL", "info")
 
-def create_bot():
-    bot_config = {
-        'name': 'TestBot',
-        'model': 'default_model',
-        'log_level': 'INFO'
-    }
-    return TestBot(bot_config)
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        reload=reload_enabled,
+        log_level=log_level,
+    )
 
-def main():
-    bot = create_bot()
-
-    def bot_interface(input_text):
-        output_text = bot.execute(input_text)
-        return output_text
-
-    def test_say_name():
-        output_text = bot.say_name()
-        return output_text
-
-    def test_generate_random_phrase():
-        output_text = bot.generate_random_phrase()
-        return output_text
-
-    with gr.Blocks(title="TestBot Interface") as iface:
-        gr.Markdown("Interact with the TestBot using Gradio interface.")
-
-        with gr.Row():
-            input_textbox = gr.Textbox(label="Enter your message")
-            output_textbox = gr.Textbox(label="Bot Response")
-
-        with gr.Row():
-            test_name_btn = gr.Button("Test Say Name")
-            test_name_output = gr.Textbox(label="Test Say Name Output")
-
-        with gr.Row():
-            test_phrase_btn = gr.Button("Test Generate Random Phrase")
-            test_phrase_output = gr.Textbox(label="Test Generate Random Phrase Output")
-
-        input_textbox.submit(bot_interface, inputs=input_textbox, outputs=output_textbox)
-        test_name_btn.click(test_say_name, outputs=test_name_output)
-        test_phrase_btn.click(test_generate_random_phrase, outputs=test_phrase_output)
-
-    iface.launch()
 
 if __name__ == "__main__":
     main()

--- a/waitaminute/novasystemcore/logging_service.py
+++ b/waitaminute/novasystemcore/logging_service.py
@@ -1,35 +1,263 @@
-"""Core logging and document creation helpers."""
+"""Logging service utilities for activity tracking and document generation."""
 from __future__ import annotations
 
+import copy
 import json
+import os
+import threading
+import uuid
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from queue import Queue
+from tempfile import NamedTemporaryFile
+from typing import Any, Callable, Dict, Optional
 
 from .database import DATA_DIR
+from .models import ActivityLog, DocumentArtifact
 
-LOG_FILE = DATA_DIR / "activity.log.jsonl"
-DOCUMENT_DIR = DATA_DIR / "documents"
+LOG_FILE_PATH = Path(
+    os.environ.get("NOVASYSTEM_LOG_FILE", DATA_DIR / "activity.log.jsonl")
+).resolve()
+DOCUMENT_DIR = Path(
+    os.environ.get("NOVASYSTEM_DOCUMENT_DIR", DATA_DIR / "documents")
+).resolve()
 DOCUMENT_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def append_to_log_file(entry: dict[str, Any]) -> None:
-    """Append the provided entry to the JSONL log file."""
-    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
-    serialisable = {
-        "timestamp": datetime.utcnow().isoformat(timespec="seconds") + "Z",
-        **entry,
-    }
-    with LOG_FILE.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(serialisable, ensure_ascii=False) + "\n")
+@dataclass(slots=True)
+class DocumentJob:
+    """In-memory representation of a queued document generation request."""
+
+    job_id: str
+    log_data: dict[str, Any]
+    doc_type: str
+    notes: str | None
 
 
-def build_document_content(doc_type: str, log_entry: dict[str, Any], notes: str | None) -> str:
+class LoggingService:
+    """High level orchestration for log persistence and document generation."""
+
+    def __init__(
+        self,
+        session_factory: Callable[[], Any],
+        *,
+        log_file: Path | None = None,
+        document_dir: Path | None = None,
+    ) -> None:
+        self.log_file = (log_file or LOG_FILE_PATH).resolve()
+        self.document_dir = (document_dir or DOCUMENT_DIR).resolve()
+        self.document_dir.mkdir(parents=True, exist_ok=True)
+
+        self._session_factory = session_factory
+        self._job_queue: Queue[DocumentJob] = Queue()
+        self._jobs: dict[str, Dict[str, Any]] = {}
+        self._jobs_lock = threading.Lock()
+        self._job_event_handler: Callable[[dict[str, Any]], None] | None = None
+
+        self._worker_thread = threading.Thread(
+            target=self._process_document_jobs,
+            name="nova-document-worker",
+            daemon=True,
+        )
+        self._worker_thread.start()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def record_log_entry(self, log_entry: dict[str, Any]) -> dict[str, Any]:
+        """Append an activity entry to the JSONL log file atomically.
+
+        The provided ``log_entry`` is expected to contain serialisable data.
+        The method enriches it with a ``recorded_at`` timestamp and writes the
+        entry to disk using an atomic append strategy.
+        """
+
+        enriched = {
+            "recorded_at": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+            **log_entry,
+        }
+        serialised = json.dumps(enriched, ensure_ascii=False)
+        self._atomic_append(serialised + "\n")
+        return enriched
+
+    def enqueue_document_generation(
+        self, log_data: dict[str, Any], doc_type: str, notes: str | None
+    ) -> dict[str, Any]:
+        """Queue a new document generation job and return its initial status."""
+
+        job_id = uuid.uuid4().hex
+        job = DocumentJob(job_id=job_id, log_data=log_data, doc_type=doc_type, notes=notes)
+
+        initial_state = {
+            "job_id": job_id,
+            "status": "queued",
+            "log_id": log_data.get("id"),
+            "doc_type": doc_type,
+            "notes": notes,
+            "document": None,
+            "error": None,
+        }
+        with self._jobs_lock:
+            self._jobs[job_id] = initial_state
+        self._notify_job_update(job_id)
+        self._job_queue.put(job)
+        return copy.deepcopy(initial_state)
+
+    def get_job_status(self, job_id: str) -> dict[str, Any] | None:
+        """Return the most recent snapshot of a queued job."""
+
+        with self._jobs_lock:
+            job = self._jobs.get(job_id)
+            return copy.deepcopy(job) if job else None
+
+    def set_job_event_handler(self, handler: Callable[[dict[str, Any]], None] | None) -> None:
+        """Register a callback to be notified whenever job status changes."""
+
+        self._job_event_handler = handler
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _atomic_append(self, payload: str) -> None:
+        """Append ``payload`` to the log file using ``O_APPEND`` semantics."""
+
+        self.log_file.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(
+            self.log_file,
+            os.O_CREAT | os.O_WRONLY | os.O_APPEND,
+            0o644,
+        )
+        try:
+            with os.fdopen(fd, "ab", closefd=True) as handle:
+                handle.write(payload.encode("utf-8"))
+        finally:
+            # ``os.fdopen`` closes ``fd`` when exiting the context manager.
+            pass
+
+    def _process_document_jobs(self) -> None:
+        """Background worker that processes document generation requests."""
+
+        while True:
+            job = self._job_queue.get()
+            if job is None:  # pragma: no cover - defensive; not used currently.
+                continue
+
+            self._update_job_state(job.job_id, status="processing", error=None)
+
+            try:
+                document_path = create_document_file(
+                    job.doc_type,
+                    job.log_data,
+                    job.notes,
+                    base_dir=self.document_dir,
+                )
+                document_info = self._persist_document_metadata(job, document_path)
+                self._update_job_state(
+                    job.job_id,
+                    status="completed",
+                    document=document_info,
+                    error=None,
+                )
+            except Exception as exc:  # pragma: no cover - logged via handler/traceback
+                self._update_job_state(
+                    job.job_id,
+                    status="failed",
+                    error=str(exc),
+                )
+
+            self._job_queue.task_done()
+
+    def _persist_document_metadata(
+        self, job: DocumentJob, file_path: Path
+    ) -> dict[str, Any]:
+        """Persist generated document metadata to the database."""
+
+        session = self._session_factory()
+        try:
+            log_id = job.log_data.get("id")
+            log: Optional[ActivityLog] = session.get(ActivityLog, log_id)
+            if log is None:
+                raise RuntimeError(f"Log entry {log_id} no longer exists")
+
+            document = DocumentArtifact(
+                log_id=log.id,
+                doc_type=job.doc_type,
+                title=self._format_document_title(job),
+                notes=job.notes,
+                path=str(file_path),
+            )
+            session.add(document)
+            session.commit()
+            session.refresh(document)
+
+            return {
+                "id": document.id,
+                "log_id": document.log_id,
+                "doc_type": document.doc_type,
+                "title": document.title,
+                "notes": document.notes,
+                "path": document.path,
+                "created_at": document.created_at,
+            }
+        finally:
+            session.close()
+
+    def _format_document_title(self, job: DocumentJob) -> str:
+        activity = job.log_data.get("activity")
+        doc_label = job.doc_type.replace("_", " ").title()
+        if activity:
+            return f"{doc_label}: {activity[:60]}"
+        return f"{doc_label} for log {job.log_data.get('id')}"
+
+    def _update_job_state(
+        self,
+        job_id: str,
+        *,
+        status: str,
+        document: dict[str, Any] | None = None,
+        error: str | None,
+    ) -> None:
+        with self._jobs_lock:
+            state = self._jobs.setdefault(job_id, {
+                "job_id": job_id,
+                "status": status,
+                "document": None,
+                "error": error,
+            })
+            state["status"] = status
+            if document is not None:
+                state["document"] = document
+            if error is not None:
+                state["error"] = error
+        self._notify_job_update(job_id)
+
+    def _notify_job_update(self, job_id: str) -> None:
+        if not self._job_event_handler:
+            return
+        snapshot = self.get_job_status(job_id)
+        if snapshot is not None:
+            try:
+                self._job_event_handler(snapshot)
+            except Exception:
+                # Best-effort notification; errors are intentionally suppressed to
+                # avoid terminating the worker thread.
+                pass
+
+
+def build_document_content(
+    doc_type: str, log_entry: dict[str, Any], notes: str | None
+) -> str:
     """Create human-readable content for generated documents."""
+
     created_at = log_entry.get("created_at")
     created_str = created_at if isinstance(created_at, str) else str(created_at)
     header = f"# {doc_type.replace('_', ' ').title()}\n\n"
-    summary = f"- **Log ID:** {log_entry['id']}\n- **Created:** {created_str}\n- **Activity:** {log_entry['activity']}\n"
+    summary = (
+        f"- **Log ID:** {log_entry.get('id')}\n"
+        f"- **Created:** {created_str}\n"
+        f"- **Activity:** {log_entry.get('activity')}\n"
+    )
     details = log_entry.get("details")
     if details:
         summary += f"- **Details:** {details}\n"
@@ -38,23 +266,50 @@ def build_document_content(doc_type: str, log_entry: dict[str, Any], notes: str 
         summary += f"- **Tags:** {', '.join(tags)}\n"
     metadata = log_entry.get("metadata") or {}
     if metadata:
-        metadata_lines = "\n".join(f"    - {key}: {value}" for key, value in metadata.items())
+        metadata_lines = "\n".join(
+            f"    - {key}: {value}" for key, value in metadata.items()
+        )
         summary += f"- **Metadata:**\n{metadata_lines}\n"
 
-    sections = [header, summary, "\n## Notes\n", (notes or "No additional notes supplied.") + "\n"]
-    sections.append("\n## Next Steps\n- [ ] Define follow-up tasks\n- [ ] Capture dependencies\n- [ ] Update the main activity log if plans change\n")
+    sections = [
+        header,
+        summary,
+        "\n## Notes\n",
+        (notes or "No additional notes supplied.") + "\n",
+    ]
+    sections.append(
+        "\n## Next Steps\n- [ ] Define follow-up tasks\n- [ ] Capture dependencies\n- [ ] Update the main activity log if plans change\n",
+    )
     return "".join(sections)
 
 
-def create_document_file(doc_type: str, log_entry: dict[str, Any], notes: str | None) -> Path:
+def create_document_file(
+    doc_type: str,
+    log_entry: dict[str, Any],
+    notes: str | None,
+    *,
+    base_dir: Path | None = None,
+) -> Path:
     """Generate a markdown document for the log entry and return the file path."""
-    DOCUMENT_DIR.mkdir(parents=True, exist_ok=True)
+
+    target_dir = (base_dir or DOCUMENT_DIR).resolve()
+    target_dir.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%S")
-    file_name = f"log-{log_entry['id']}-{doc_type}-{timestamp}.md"
-    file_path = DOCUMENT_DIR / file_name
+    file_name = f"log-{log_entry.get('id')}-{doc_type}-{timestamp}.md"
+    destination = target_dir / file_name
     content = build_document_content(doc_type, log_entry, notes)
-    file_path.write_text(content, encoding="utf-8")
-    return file_path
+
+    with NamedTemporaryFile("w", encoding="utf-8", dir=target_dir, delete=False) as tmp_file:
+        tmp_file.write(content)
+        tmp_path = Path(tmp_file.name)
+    tmp_path.replace(destination)
+    return destination
 
 
-__all__ = ["append_to_log_file", "create_document_file", "LOG_FILE", "DOCUMENT_DIR"]
+__all__ = [
+    "LoggingService",
+    "LOG_FILE_PATH",
+    "DOCUMENT_DIR",
+    "build_document_content",
+    "create_document_file",
+]

--- a/waitaminute/novasystemcore/schemas.py
+++ b/waitaminute/novasystemcore/schemas.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -20,6 +20,15 @@ class DocumentResponse(BaseModel):
     notes: str | None
     created_at: datetime
     download_url: str
+
+
+class DocumentJobStatus(BaseModel):
+    job_id: str
+    status: Literal["queued", "processing", "completed", "failed"]
+    document: DocumentResponse | None = Field(
+        None, description="Document metadata when the job has completed successfully."
+    )
+    error: str | None = Field(None, description="Error information if the job failed.")
 
 
 class LogCreate(BaseModel):
@@ -52,6 +61,7 @@ class LogListResponse(BaseModel):
 __all__ = [
     "DocumentCreate",
     "DocumentResponse",
+    "DocumentJobStatus",
     "LogCreate",
     "LogResponse",
     "LogListResponse",


### PR DESCRIPTION
## Summary
- replace the experimental Gradio harness with a uvicorn-powered entry point for the FastAPI app
- expand the logging service into a reusable backend that writes logs atomically and queues document generation jobs
- extend the FastAPI application with REST and WebSocket endpoints, job status polling, and broadcast notifications using the new service
- add API schemas for document job tracking

## Testing
- `python -m compileall waitaminute/novasystemcore` *(fails: existing indentation error in waitaminute/novasystemcore/routers/Router.py)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3dd2f24c8320a74c2f1d03045b46