### PR TITLE
Handle run metadata updates and cover Nova type detection

### DIFF
--- a/novasystem/database.py
+++ b/novasystem/database.py
@@ -143,6 +143,7 @@ class DatabaseManager:
 
     def update_run(self, run_id: int, status: Optional[str] = None,
                   success: Optional[bool] = None, summary: Optional[str] = None,
+                  metadata: Optional[Dict[str, Any]] = None,
                   end_time: bool = False) -> bool:
         """
         Update a run record.
@@ -152,6 +153,7 @@ class DatabaseManager:
             status: New status (e.g., 'completed', 'failed').
             success: Whether the run was successful.
             summary: Summary of the run results.
+            metadata: Additional metadata to store (will be serialized as JSON).
             end_time: Whether to update the end_time to now.
 
         Returns:
@@ -175,6 +177,16 @@ class DatabaseManager:
             if summary is not None:
                 query_parts.append("summary = ?")
                 params.append(summary)
+
+            if metadata is not None:
+                try:
+                    metadata_json = json.dumps(metadata) if metadata else None
+                except (TypeError, ValueError) as e:
+                    logger.error(f"Invalid metadata for run update: {str(e)}")
+                    return False
+
+                query_parts.append("metadata = ?")
+                params.append(metadata_json)
 
             if end_time:
                 query_parts.append("end_time = ?")

--- a/tests/test_nova_repository_detection.py
+++ b/tests/test_nova_repository_detection.py
@@ -1,0 +1,36 @@
+"""Tests for Nova repository processing metadata handling."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from novasystem.nova import Nova
+
+
+def test_process_repository_records_detected_type(tmp_path, monkeypatch):
+    """Ensure Nova can persist detected repository type metadata without errors."""
+
+    repo_dir = tmp_path / "sample_repo"
+    repo_dir.mkdir()
+    # Presence of a requirements file should trigger Python detection
+    (repo_dir / "requirements.txt").write_text("flask==2.0.0\n", encoding="utf-8")
+
+    db_path = tmp_path / "nova-test.db"
+    nova = Nova(db_path=str(db_path), test_mode=True)
+
+    # Avoid heavy repository and command processing by stubbing discovery
+    monkeypatch.setattr(
+        nova.repo_handler,
+        "find_documentation_files",
+        lambda path: [],
+        raising=False,
+    )
+
+    result = nova.process_repository(str(repo_dir), detect_type=True)
+
+    assert result["run_id"] > 0
+
+    run_record = nova.db_manager.get_run(result["run_id"])
+    assert run_record is not None
+    assert run_record.get("metadata", {}).get("repository_type") == "python"


### PR DESCRIPTION
## Summary
- allow `DatabaseManager.update_run` to accept optional metadata and persist JSON safely
- ensure updates only change provided fields and validate metadata serialization
- add regression test verifying `Nova.process_repository` records detected repository types without raising errors

## Testing
- pytest tests/test_nova_repository_detection.py

------
https://chatgpt.com/codex/tasks/task_e_68cd9d72277c8320bb561b30d1e4f49d