### PR TITLE
Expose parser deduplication API and tests

### DIFF
--- a/novasystem/parser.py
+++ b/novasystem/parser.py
@@ -134,7 +134,7 @@ class DocumentationParser:
             commands.extend(llm_commands)
 
         # Deduplicate commands
-        unique_commands = self._deduplicate_commands(commands)
+        unique_commands = self.deduplicate_commands(commands)
 
         return unique_commands
 
@@ -480,6 +480,10 @@ class DocumentationParser:
 
         # Ensure priority is in range [1, 100]
         return max(1, min(100, priority))
+
+    def deduplicate_commands(self, commands: List[Command]) -> List[Command]:
+        """Public wrapper for command deduplication."""
+        return self._deduplicate_commands(commands)
 
     def _deduplicate_commands(self, commands: List[Command]) -> List[Command]:
         """

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,49 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from novasystem.parser import Command, CommandSource, CommandType, DocumentationParser
+
+
+def _make_command(text: str, priority: int) -> Command:
+    return Command(
+        text=text,
+        source=CommandSource.CODE_BLOCK,
+        command_type=CommandType.SHELL,
+        priority=priority,
+    )
+
+
+def test_deduplicate_commands_prefers_higher_priority():
+    parser = DocumentationParser()
+    commands = [
+        _make_command("pip install example", priority=10),
+        _make_command("pip install example", priority=80),
+        _make_command("npm install other", priority=60),
+        _make_command("npm install other", priority=20),
+    ]
+
+    deduped = parser.deduplicate_commands(commands)
+
+    assert len(deduped) == 2
+    command_texts = {cmd.text: cmd for cmd in deduped}
+    assert command_texts["pip install example"].priority == 80
+    assert command_texts["npm install other"].priority == 60
+
+
+def test_get_installation_commands_deduplicates():
+    parser = DocumentationParser()
+    content = """
+```bash
+pip install package
+```
+
+Install via inline `pip install package` if needed.
+"""
+
+    commands = parser.get_installation_commands(content)
+
+    occurrences = [cmd for cmd in commands if cmd.text == "pip install package"]
+    assert len(occurrences) == 1
+    assert occurrences[0].priority >= 50


### PR DESCRIPTION
## Summary
- add a public `deduplicate_commands` helper on the documentation parser and use it internally
- cover parser deduplication behavior with unit tests focused on priority handling

## Testing
- pytest tests/test_parser.py

------
https://chatgpt.com/codex/tasks/task_e_68cda91e3bbc8320a823f540c8129970