### PR TITLE
Fix repository cleanup invocation and add regression test

### DIFF
--- a/novasystem/nova.py
+++ b/novasystem/nova.py
@@ -267,8 +267,8 @@ class Nova:
 
         finally:
             # Clean up temporary directory if created
-            if temp_dir and os.path.exists(temp_dir):
-                self.repo_handler.cleanup(temp_dir)
+            if temp_dir:
+                self.repo_handler.cleanup()
 
     def _detect_repository_type(self, repo_path: str) -> Optional[str]:
         """

--- a/tests/test_nova_repository_detection.py
+++ b/tests/test_nova_repository_detection.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -34,3 +35,29 @@ def test_process_repository_records_detected_type(tmp_path, monkeypatch):
     run_record = nova.db_manager.get_run(result["run_id"])
     assert run_record is not None
     assert run_record.get("metadata", {}).get("repository_type") == "python"
+
+
+def test_process_repository_remote_cleanup(tmp_path, monkeypatch):
+    """Processing a remote repository should clean up temporary clones safely."""
+
+    db_path = tmp_path / "nova-test.db"
+    nova = Nova(db_path=str(db_path), test_mode=True)
+
+    work_dir = Path(nova.repo_handler.work_dir)
+    fake_clone_dir = work_dir / "example_owner_repo"
+
+    def fake_clone(repo_url: str) -> str:  # pragma: no cover - exercised via Nova
+        fake_clone_dir.mkdir(parents=True, exist_ok=True)
+        (fake_clone_dir / "README.md").write_text("# Test\n", encoding="utf-8")
+        nova.repo_handler.repo_dir = str(fake_clone_dir)
+        nova.repo_handler.repo_url = repo_url
+        return str(fake_clone_dir)
+
+    monkeypatch.setattr(nova.repo_handler, "clone_repository", fake_clone)
+    monkeypatch.setattr(nova.repo_handler, "find_documentation_files", lambda _: [])
+
+    result = nova.process_repository("https://example.com/example/repo.git", detect_type=False)
+
+    assert not result["success"]
+    assert "No installation commands" in result["message"]
+    assert not fake_clone_dir.exists()


### PR DESCRIPTION
## Summary
- ensure Nova invokes the repository handler cleanup without passing an unexpected argument
- harden RepositoryHandler.cleanup to accept optional targets, guard against unsafe removals, and recreate temporary work spaces when removed
- add a regression test confirming that processing a remote repository cleans up its clone without crashing

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cdae74a8188320b5c9824875bfa143