### PR TITLE
Secure PocketBase admin credentials

### DIFF
--- a/waitaminute/dev/src/core/tools/README.md
+++ b/waitaminute/dev/src/core/tools/README.md
@@ -3,3 +3,18 @@ Store modules you want NovaSystem to use inside this directory.
 Nova should load these modules into its infrastructure automatically when it starts.
 
 It doesn't, but it should. That's on the todo list.
+
+## CrewAI PocketBase helper
+
+The `crewai/pocketbase_test.py` helper now expects credentials to be provided
+via environment variables before execution:
+
+```bash
+export POCKETBASE_ADMIN_EMAIL="admin@example.com"
+export POCKETBASE_ADMIN_PASSWORD="super-secret-password"
+python pocketbase_test.py < input.json
+```
+
+Optionally, set `POCKETBASE_URL` to point to a non-local PocketBase instance.
+The script will raise an explicit error if any required credential variable is
+missing.

--- a/waitaminute/dev/src/core/tools/crewai/pocketbase_test.py
+++ b/waitaminute/dev/src/core/tools/crewai/pocketbase_test.py
@@ -1,30 +1,72 @@
-import sys
+"""Helper script for updating PocketBase records used by CrewAI tools."""
+
+from __future__ import annotations
+
 import json
+import os
+import sys
+from typing import Iterable
+
 import pocketbase
 
-def update_pocketbase(messages):
-    pb = pocketbase.PocketBase('http://127.0.0.1:8090')
+POCKETBASE_URL = os.getenv("POCKETBASE_URL", "http://127.0.0.1:8090")
 
-    admin_email = 'ctavolazzi@gmail.com'
-    admin_password = 'adminpassword'
+
+def _get_admin_credentials() -> tuple[str, str]:
+    """Fetch PocketBase admin credentials from environment variables.
+
+    Returns:
+        A tuple containing the admin email and password.
+
+    Raises:
+        RuntimeError: If one or both required environment variables are missing.
+    """
+
+    email = os.getenv("POCKETBASE_ADMIN_EMAIL")
+    password = os.getenv("POCKETBASE_ADMIN_PASSWORD")
+
+    missing = [
+        name
+        for name, value in (
+            ("POCKETBASE_ADMIN_EMAIL", email),
+            ("POCKETBASE_ADMIN_PASSWORD", password),
+        )
+        if not value
+    ]
+
+    if missing:
+        missing_vars = ", ".join(missing)
+        raise RuntimeError(
+            "Missing required PocketBase admin credential environment "
+            f"variable(s): {missing_vars}. Set them before running this script."
+        )
+
+    return email, password
+
+
+def update_pocketbase(messages: Iterable[dict]) -> None:
+    """Update the PocketBase record with the supplied chat messages."""
+
+    pb = pocketbase.PocketBase(POCKETBASE_URL)
+
+    admin_email, admin_password = _get_admin_credentials()
 
     try:
         # Authenticate the admin account
         auth_data = pb.admins.auth_with_password(admin_email, admin_password)
 
         if auth_data:
-            admin_token = auth_data.token
-            print(f"Admin authenticated successfully. Token: {admin_token}")
+            print("Admin authenticated successfully.")
 
             # Prepare the data to be sent to the crewai_runs collection
             data = {
-                "json": json.dumps({"messages": messages}),
-                "description": "Updated messages from the AI chat"
+                "json": json.dumps({"messages": list(messages)}),
+                "description": "Updated messages from the AI chat",
             }
 
             try:
                 # Update the record in the crewai_runs collection
-                response = pb.collection('ai_chats').update('ic74gxca6sa97sp', data)
+                response = pb.collection("ai_chats").update("ic74gxca6sa97sp", data)
 
                 if response:
                     print("Record updated successfully:")
@@ -33,22 +75,26 @@ def update_pocketbase(messages):
                     print(f"Description: {response.description}")
                 else:
                     print("Failed to update record.")
-            except Exception as e:
-                print(f"Error updating record: {str(e)}")
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                print(f"Error updating record: {exc}")
 
             # Clear the auth store to log out the admin account
             pb.auth_store.clear()
         else:
             print("Failed to authenticate admin.")
-    except Exception as e:
-        print(f"Error: {str(e)}")
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        print(f"Error: {exc}")
 
-# Read messages from stdin
-input_data = sys.stdin.read()
 
-# Parse the input data as JSON
-data = json.loads(input_data)
-messages = data['messages']
+def main() -> None:
+    """Entry point for CLI execution."""
 
-# Update PocketBase
-update_pocketbase(messages)
+    input_data = sys.stdin.read()
+    data = json.loads(input_data)
+    messages = data["messages"]
+
+    update_pocketbase(messages)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- load PocketBase admin credentials from environment variables and validate their presence
- keep PocketBase tokens out of stdout while updating the AI chat record
- document the required environment configuration for running the helper script

## Testing
- ⚠️ `python waitaminute/dev/src/core/tools/crewai/pocketbase_test.py <<'EOF' {"messages": [{"role": "user", "content": "Hello"}]} EOF` *(fails: missing `pocketbase` dependency in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf16328bc88320929eed49d5d5e63f